### PR TITLE
Add RabbitMQ Deployment, Service, and PVC

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The following services are included in this setup:
 - Redis
 - Microsoft SQL Server (MSSQL)
 - Azurite (Azure Storage Emulator)
+- RabbitMQ
 
 ## Directory Structure
 
@@ -27,7 +28,10 @@ The following services are included in this setup:
     ├── mssql/
     │   ├── deployment.yaml
     │   └── service.yaml
-    └── azurite/
+    ├── azurite/
+    │   ├── deployment.yaml
+    │   └── service.yaml
+    └── rabbitmq/
         ├── deployment.yaml
         └── service.yaml
 ```
@@ -52,13 +56,18 @@ After deploying the services, you can access them using the following connection
 
 - MongoDB: `mongodb://admin:password@localhost:30017`
   - Username: `admin`
-  - Password: `password`
+  - Password: `p@ssw0rd`
 - Redis: `redis://localhost:30379`
-- MSSQL: `Server=localhost,30433;User Id=sa;Password=YourStrong!Passw0rd;`
+- MSSQL: `Server=localhost,30433;User Id=sa;Password=P@ssw0rd;`
 - Azurite:
   - Blob: `http://localhost:31000`
   - Queue: `http://localhost:31001`
   - Table: `http://localhost:31002`
+- RabbitMQ:
+  - AMQP: `amqp://localhost:30672`
+  - Management UI: `http://localhost:31672`
+  - Username: `admin`
+  - Password: `p@ssw0rd`
 
 Note: These services are exposed using NodePort services. Make sure your local Kubernetes cluster allows access to these NodePorts.
 

--- a/k8s/deployment/rabbitmq-deploy.yaml
+++ b/k8s/deployment/rabbitmq-deploy.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rabbitmq
+  namespace: data
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rabbitmq
+  template:
+    metadata:
+      labels:
+        app: rabbitmq
+    spec:
+      containers:
+        - name: rabbitmq
+          image: rabbitmq:4.0-management-alpine
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: RABBITMQ_DEFAULT_USER
+              value: "admin"
+            - name: RABBITMQ_DEFAULT_PASS
+              value: "p@ssw0rd"
+          ports:
+            - containerPort: 5672
+            - containerPort: 15672
+          volumeMounts:
+            - name: rabbitmq-pvc
+              mountPath: /var/lib/rabbitmq
+      volumes:
+        - name: rabbitmq-pvc
+          persistentVolumeClaim:
+            claimName: rabbitmq-pvc

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -16,5 +16,8 @@ resources:
   - storage/azurite-pvc.yaml
   - deployment/azurite-deploy.yaml
   - service/azurite-svc.yaml
+  - storage/rabbitmq-pvc.yaml
+  - deployment/rabbitmq-deploy.yaml
+  - service/rabbitmq-svc.yaml
 
 # You can add more configurations here as needed

--- a/k8s/service/azurite-svc.yaml
+++ b/k8s/service/azurite-svc.yaml
@@ -12,11 +12,14 @@ spec:
       port: 10000
       targetPort: 10000
       nodePort: 32000 # NodePort for blob
+      name: blob
     - protocol: TCP
       port: 10001
       targetPort: 10001
       nodePort: 32001 # NodePort for queue
+      name: queue
     - protocol: TCP
       port: 10002
       targetPort: 10002
       nodePort: 32002 # NodePort for table
+      name: table

--- a/k8s/service/rabbitmq-svc.yaml
+++ b/k8s/service/rabbitmq-svc.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rabbitmq
+  namespace: data
+spec:
+  type: NodePort
+  selector:
+    app: rabbitmq
+  ports:
+    - protocol: TCP
+      port: 5672
+      targetPort: 5672
+      nodePort: 30672
+      name: rabbitmq
+    - protocol: TCP
+      port: 15672
+      targetPort: 15672
+      nodePort: 31672
+      name: rabbitmq-ui

--- a/k8s/storage/rabbitmq-pvc.yaml
+++ b/k8s/storage/rabbitmq-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rabbitmq-pvc
+  namespace: data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
- Added a new RabbitMQ deployment configuration in `k8s/deployment/rabbitmq-deploy.yaml`
  - Configured RabbitMQ container with management plugin
  - Set environment variables for default user and password
  - Exposed ports 5672 and 15672 for RabbitMQ and its management interface
  - Mounted persistent volume for RabbitMQ data storage

- Created a new PersistentVolumeClaim for RabbitMQ in `k8s/storage/rabbitmq-pvc.yaml`
  - Requested 1Gi of storage with ReadWriteOnce access mode

- Added a new Service for RabbitMQ in `k8s/service/rabbitmq-svc.yaml`
  - Configured NodePort service type to expose RabbitMQ service on the cluster

- Updated `k8s/kustomization.yaml` to include the new RabbitMQ resources
  - Added references to the RabbitMQ deployment, service, and PVC

- Modified `k8s/service/azurite-svc.yaml` to include named ports for better clarity

This commit introduces RabbitMQ to the Kubernetes cluster, ensuring persistent storage and proper service exposure. The changes also enhance the Azurite service configuration for improved readability.