### PR TITLE
Add Prometheus Monitoring Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kubernetes Development Environment
 
-This repository contains Kubernetes manifests for setting up a local development environment with various data services using Kustomize.
+This repository contains Kubernetes manifests for setting up a local development environment with various data services and monitoring using Kustomize.
 
 ## Services
 
@@ -11,6 +11,7 @@ The following services are included in this setup:
 - Microsoft SQL Server (MSSQL)
 - Azurite (Azure Storage Emulator)
 - RabbitMQ
+- Prometheus (Monitoring)
 
 ## Directory Structure
 
@@ -19,21 +20,32 @@ The following services are included in this setup:
 ├── README.md
 └── k8s/
     ├── kustomization.yaml
-    ├── mongodb/
-    │   ├── deployment.yaml
-    │   └── service.yaml
-    ├── redis/
-    │   ├── deployment.yaml
-    │   └── service.yaml
-    ├── mssql/
-    │   ├── deployment.yaml
-    │   └── service.yaml
-    ├── azurite/
-    │   ├── deployment.yaml
-    │   └── service.yaml
-    └── rabbitmq/
-        ├── deployment.yaml
-        └── service.yaml
+    ├── namespace/
+    │   ├── data.yaml
+    │   └── metrics.yaml
+    ├── config/
+    │   └── prometheus.yaml
+    ├── storage/
+    │   ├── mongo.yaml
+    │   ├── redis.yaml
+    │   ├── mssql.yaml
+    │   ├── azurite.yaml
+    │   ├── rabbitmq.yaml
+    │   └── prometheus.yaml
+    ├── deployment/
+    │   ├── mongo.yaml
+    │   ├── redis.yaml
+    │   ├── mssql.yaml
+    │   ├── azurite.yaml
+    │   ├── rabbitmq.yaml
+    │   └── prometheus.yaml
+    └── service/
+        ├── mongo.yaml
+        ├── redis.yaml
+        ├── mssql.yaml
+        ├── azurite.yaml
+        ├── rabbitmq.yaml
+        └── prometheus.yaml
 ```
 
 ## Setup Instructions
@@ -68,6 +80,8 @@ After deploying the services, you can access them using the following connection
   - Management UI: `http://localhost:31672`
   - Username: `admin`
   - Password: `p@ssw0rd`
+- Prometheus:
+  - Web UI: `http://localhost:30090`
 
 Note: These services are exposed using NodePort services. Make sure your local Kubernetes cluster allows access to these NodePorts.
 
@@ -77,21 +91,32 @@ The `kustomization.yaml` file in the `k8s/` directory manages the deployment of 
 
 Individual service configurations can be adjusted by modifying the respective YAML files in the service-specific directories under `k8s/`.
 
+### Prometheus Configuration
+
+Prometheus is configured using a ConfigMap located at `k8s/config/prometheus.yaml`. You can modify this file to adjust scraping intervals, add new targets, or customize other Prometheus settings.
+
+## Namespaces
+
+The services are organized into two namespaces:
+
+- `data`: Contains all data services (MongoDB, Redis, MSSQL, Azurite, RabbitMQ)
+- `metrics`: Contains the Prometheus monitoring service
+
 ## Troubleshooting
 
 If you encounter any issues, please check the following:
 
 1. Ensure all pods are running:
    ```
-   kubectl get pods
+   kubectl get pods --all-namespaces
    ```
 2. Check pod logs for any errors:
    ```
-   kubectl logs <pod-name>
+   kubectl logs <pod-name> -n <namespace>
    ```
 3. Verify services are exposed correctly:
    ```
-   kubectl get services
+   kubectl get services --all-namespaces
    ```
 
 ## Contributing

--- a/k8s/config/prometheus.yaml
+++ b/k8s/config/prometheus.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: metrics
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+      scrape_timeout: 10s
+      evaluation_interval: 15s
+    scrape_configs:
+      - job_name: 'prometheus'
+        static_configs:
+          - targets: ['localhost:9090']
+

--- a/k8s/deployment/prometheus.yaml
+++ b/k8s/deployment/prometheus.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: metrics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+        - name: prometheus
+          image: prom/prometheus
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+            requests:
+              cpu: "250m"
+              memory: "256Mi"
+          ports:
+            - containerPort: 9090
+          volumeMounts:
+            - name: prometheus-config
+              mountPath: /etc/prometheus
+            - name: prometheus-pvc
+              mountPath: /data
+      volumes:
+        - name: prometheus-config
+          configMap:
+            name: prometheus-config
+        - name: prometheus-pvc
+          persistentVolumeClaim:
+            claimName: prometheus-pvc

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
   - namespace/data.yaml
+  - namespace/metrics.yaml
   - storage/mongo.yaml
   - deployment/mongo.yaml
   - service/mongo.yaml
@@ -18,3 +19,7 @@ resources:
   - storage/rabbitmq.yaml
   - deployment/rabbitmq.yaml
   - service/rabbitmq.yaml
+  - config/prometheus.yaml
+  - storage/prometheus.yaml
+  - deployment/prometheus.yaml
+  - service/prometheus.yaml

--- a/k8s/namespace/metrics.yaml
+++ b/k8s/namespace/metrics.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metrics

--- a/k8s/service/prometheus.yaml
+++ b/k8s/service/prometheus.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: metrics
+spec:
+  type: NodePort
+  ports:
+    - port: 9090
+      targetPort: 9090
+      nodePort: 30090
+  selector:
+    app: prometheus
+

--- a/k8s/storage/prometheus.yaml
+++ b/k8s/storage/prometheus.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prometheus-pvc
+  namespace: metrics
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi


### PR DESCRIPTION
- Updated README.md to include Prometheus monitoring service setup and access details.
- Added Prometheus configuration file at k8s/config/prometheus.yaml.
  - Configures Prometheus scraping intervals and targets.
- Created Prometheus deployment file at k8s/deployment/prometheus.yaml.
  - Defines Prometheus deployment with resource requests and limits.
- Modified k8s/kustomization.yaml to include Prometheus resources.
  - Ensures Prometheus resources are applied during kustomize apply.
- Added metrics namespace definition at k8s/namespace/metrics.yaml.
  - Segregates monitoring services into a dedicated namespace.
- Created Prometheus service file at k8s/service/prometheus.yaml.
  - Exposes Prometheus via NodePort for external access.
- Added PersistentVolumeClaim for Prometheus at k8s/storage/prometheus.yaml.
  - Ensures Prometheus has persistent storage for metrics data.

This commit sets up Prometheus as a monitoring service in the Kubernetes development environment, providing detailed configuration and access instructions.